### PR TITLE
Revert to protocol version 61402.

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -30,7 +30,7 @@ static const int DATABASE_VERSION = 70509;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 61403;
+static const int PROTOCOL_VERSION = 61402;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
61403 will require a complete network update because of the masternodes.
